### PR TITLE
Enable quiet mode when writing output to stdout

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3306,6 +3306,9 @@ def parse_args(args=None, ignore_additional_args=False):
          outfile = sys.stdout.buffer
       except AttributeError:
          outfile = sys.stdout
+      # enable quiet mode when writing output to stdout
+      # otherwise informational text output would be mixed into the SVG output
+      options.quiet = True
 
    return options, [infile, outfile]
 


### PR DESCRIPTION
If quiet mode is not enabled when writing SVG output to stdout, all informational text output ends up mixed into the SVG output (notably the status report at the end, e.g. *"Scour processed file "x.svg" in 21 ms: 5708/13196 bytes new/orig -> 43.3%"*)

This fixes #47.