### PR TITLE
Don't escape quotes ('/") in text nodes and attributes.

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2752,7 +2752,10 @@ def remapNamespacePrefix(node, oldprefix, newprefix):
 
 
 def makeWellFormed(str):
-   xml_ents = { '<':'&lt;', '>':'&gt;', '&':'&amp;', "'":'&apos;', '"':'&quot;'}
+   # Don't escape quotation marks for now as they are fine in text nodes
+   # as well as in attributes if used reciprocally
+   #    xml_ents = { '<':'&lt;', '>':'&gt;', '&':'&amp;', "'":'&apos;', '"':'&quot;'}
+   xml_ents = { '<':'&lt;', '>':'&gt;', '&':'&amp;'}
 
 #  starr = []
 #  for c in str:

--- a/testscour.py
+++ b/testscour.py
@@ -1114,7 +1114,7 @@ class EnsureLineEndings(unittest.TestCase):
 
 class XmlEntities(unittest.TestCase):
 	def runTest(self):
-		self.assertEqual( scour.makeWellFormed('<>&"\''), '&lt;&gt;&amp;&quot;&apos;',
+		self.assertEqual( scour.makeWellFormed('<>&'), '&lt;&gt;&amp;',
 			'Incorrectly translated XML entities')
 
 class DoNotStripCommentsOutsideOfRoot(unittest.TestCase):


### PR DESCRIPTION
- In text nodes quotes are fine
- In attributes quotes are fine if used reciprocally.

Escaping in the latter case often causes issues, e.g. with quoted font names (#21) or inline CSS styles (#56), while it probably does not gain anything (if quotes are wrongly used in attribute names the XML is most likely invalid to start with)