### PR TITLE
Remove obsolete Psyco dependency

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -71,13 +71,6 @@ try:
 except ImportError:
    sys.stderr.write("Scour requires at least Python 2.7 or Python 3.3+.")
 
-# Import Psyco if available
-try:
-   import psyco
-   psyco.full()
-except ImportError:
-   pass
-
 # select the most precise walltime measurement function available on the platform
 if sys.platform.startswith('win'):
    walltime = time.clock


### PR DESCRIPTION
This module does not work with Python 2.7 and later, according to https://pypi.python.org/pypi/psyco/1.6 and http://psyco.sourceforge.net.