### PR TITLE
Add options to remove descriptive elements

### DIFF
--- a/testscour.py
+++ b/testscour.py
@@ -141,15 +141,59 @@ class NoAdobeXPathElements(unittest.TestCase):
 			lambda e: e.namespaceURI != 'http://ns.adobe.com/XPath/1.0/'), False,
 			'Found Adobe XPath elements' )
 
+class DoNotRemoveTitleWithOnlyText(unittest.TestCase):
+	def runTest(self):
+		doc = scour.scourXmlFile('unittests/descriptive-elements-with-text.svg')
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'title')), 1,
+			'Removed title element with only text child' )
+
+class RemoveEmptyTitleElement(unittest.TestCase):
+	def runTest(self):
+		doc = scour.scourXmlFile('unittests/empty-descriptive-elements.svg')
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'title')), 0,
+			'Did not remove empty title element' )
+
+class DoNotRemoveDescriptionWithOnlyText(unittest.TestCase):
+	def runTest(self):
+		doc = scour.scourXmlFile('unittests/descriptive-elements-with-text.svg')
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'desc')), 1,
+			'Removed description element with only text child' )
+
+class RemoveEmptyDescriptionElement(unittest.TestCase):
+	def runTest(self):
+		doc = scour.scourXmlFile('unittests/empty-descriptive-elements.svg')
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'desc')), 0,
+			'Did not remove empty description element' )
+
 class DoNotRemoveMetadataWithOnlyText(unittest.TestCase):
 	def runTest(self):
-		doc = scour.scourXmlFile('unittests/metadata-with-text.svg')
+		doc = scour.scourXmlFile('unittests/descriptive-elements-with-text.svg')
 		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'metadata')), 1,
 			'Removed metadata element with only text child' )
 
 class RemoveEmptyMetadataElement(unittest.TestCase):
 	def runTest(self):
-		doc = scour.scourXmlFile('unittests/empty-metadata.svg')
+		doc = scour.scourXmlFile('unittests/empty-descriptive-elements.svg')
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'metadata')), 0,
+			'Did not remove empty metadata element' )
+
+class DoNotRemoveDescriptiveElementsWithOnlyText(unittest.TestCase):
+	def runTest(self):
+		doc = scour.scourXmlFile('unittests/descriptive-elements-with-text.svg')
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'title')), 1,
+			'Removed title element with only text child' )
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'desc')), 1,
+			'Removed description element with only text child')
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'metadata')), 1,
+			'Removed metadata element with only text child' )
+
+class RemoveEmptyDescriptiveElements(unittest.TestCase):
+	def runTest(self):
+		doc = scour.scourXmlFile('unittests/empty-descriptive-elements.svg')
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'title')), 0,
+			'Did not remove empty title element' )
+		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'desc')), 0,
+			'Did not remove empty description element' )
 		self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'metadata')), 0,
 			'Did not remove empty metadata element' )
 
@@ -1152,12 +1196,33 @@ class PathImplicitLineWithMoveCommands(unittest.TestCase):
 		self.assertEqual( path.getAttribute('d'), "m100 100v100m200-100h-200m200 100v-100",
 			"Implicit line segments after move not preserved")
 
+class RemoveTitlesOption(unittest.TestCase):
+	def runTest(self):
+		doc = scour.scourXmlFile('unittests/full-descriptive-elements.svg',
+			scour.parse_args(['--remove-titles']))
+		self.assertEqual(doc.childNodes.length, 1,
+			'Did not remove <title> tag with --remove-titles')
+
+class RemoveDescriptionsOption(unittest.TestCase):
+	def runTest(self):
+		doc = scour.scourXmlFile('unittests/full-descriptive-elements.svg',
+			scour.parse_args(['--remove-descriptions']))
+		self.assertEqual(doc.childNodes.length, 1,
+			'Did not remove <desc> tag with --remove-descriptions')
+
 class RemoveMetadataOption(unittest.TestCase):
 	def runTest(self):
-		doc = scour.scourXmlFile('unittests/full-metadata.svg',
+		doc = scour.scourXmlFile('unittests/full-descriptive-elements.svg',
 			scour.parse_args(['--remove-metadata']))
 		self.assertEqual(doc.childNodes.length, 1,
 			'Did not remove <metadata> tag with --remove-metadata')
+
+class RemoveDescriptiveElementsOption(unittest.TestCase):
+	def runTest(self):
+		doc = scour.scourXmlFile('unittests/full-descriptive-elements.svg',
+			scour.parse_args(['--remove-descriptive-elements']))
+		self.assertEqual(doc.childNodes.length, 1,
+			'Did not remove <title>, <desc> and <metadata> tags with --remove-descriptive-elements')
 
 class EnableCommentStrippingOption(unittest.TestCase):
 	def runTest(self):

--- a/unittests/descriptive-elements-with-text.svg
+++ b/unittests/descriptive-elements-with-text.svg
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg">
+  <title>This is a title element with only text node children</title>
+  <desc>This is a desc element with only text node children</desc>
   <metadata>This is a metadata element with only text node children</metadata>
 </svg>

--- a/unittests/empty-descriptive-elements.svg
+++ b/unittests/empty-descriptive-elements.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
+  <title></title>
+  <desc></desc>
   <metadata></metadata>
 </svg>

--- a/unittests/full-descriptive-elements.svg
+++ b/unittests/full-descriptive-elements.svg
@@ -1,4 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg">
+    <title xmlns:mytitle="http://example.org/mytitle">
+      <mytitle:title>This is an example SVG file</mytitle:title>
+      <mytitle:desc>Unit test for Scour's --remove-titles option</mytitle:desc>
+    </title>
+    <desc xmlns:mydesc="http://example.org/mydesc">
+      <mydesc:title>This is an example SVG file</mydesc:title>
+      <mydesc:para>Unit test for Scour's
+      <mydesc:emph>--remove-descriptions</mydesc:emph> option</mydesc:para>
+    </desc>
     <metadata>
       <rdf:RDF
            xmlns:rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"


### PR DESCRIPTION
Closes #38. I’ve added three new options:
- `--remove-titles` (removes `<title>`)
- `--remove-descriptions` (removes `<desc>`)
- `--remove-descriptive-elements` (removes `<title>`, `<desc>` and `<metadata>`)

I’ve also added tests for each (9 in total) and modified the corresponding SVG files. I’m not that familiar with Python, so constructive comments are appreciated! I wasn’t sure about adding a type check to `removeDescriptiveElements()` (for the set type), but apparently that is not very Python’y?