### PR TITLE
Improve precision options for smaller output size

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3286,7 +3286,7 @@ def scourString(in_string, options=None):
     scouringRoundNearZero = False
     scouringRoundNearZeroC = False
     # must have at least 1 significant digit
-    # interrept digits == 0 as rounding to nearest int for values between -1 and 1 
+    # interrept digits == 0 as rounding to nearest int for values between -1 and 1
     if(options.digits == 0):
         options.digits = 1
         scouringRoundNearZero = True

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2630,24 +2630,10 @@ def scourUnitlessLength(length, needsRendererWorkaround=False, isControlPoint=Fa
     # reduce numeric precision
     # plus() corresponds to the unary prefix plus operator and applies context precision and rounding
     sContext = scouringContext
-    roundNearZero = scouringRoundNearZero
     if(isControlPoint):
         sContext = scouringContextC
-        roundNearZero = scouringRoundNearZeroC
 
-    if(roundNearZero and length > -1 and length < 1):
-        length = getcontext().create_decimal(str(int(round(length))))
-    else:
-        if(scouringKeepIntPrecision):
-            length_as_int = int(round(length))
-            len_length_as_int = len(str(abs(length_as_int)))
-            if(sContext.prec < len_length_as_int):
-                length = getcontext().create_decimal(str(int(round(length))))
-            else:
-                # preserve all digits left of the decimal point
-                length = sContext.plus(length)
-        else:
-            length = sContext.plus(length)
+    length = sContext.plus(length)
 
     # remove trailing zeroes as we do not care for significance
     intLength = length.to_integral_value()
@@ -3282,24 +3268,10 @@ def scourString(in_string, options=None):
     # to minimize errors
     global scouringContext
     global scouringContextC
-    global scouringKeepIntPrecision
-    global scouringRoundNearZero
-    global scouringRoundNearZeroC
-    scouringKeepIntPrecision = options.keep_int_precision
-    scouringRoundNearZero = False
-    scouringRoundNearZeroC = False
-    # must have at least 1 significant digit
-    # interrept digits == 0 as rounding to nearest int for values between -1 and 1
     if(options.cdigits < 0):
         # cdigits is negative value so use digits instead
         options.cdigits = options.digits
 
-    if(options.digits == 0):
-        options.digits = 1
-        scouringRoundNearZero = True
-    if(options.cdigits == 0):
-        options.cdigits = 1
-        scouringRoundNearZeroC = True
     scouringContext = Context(prec=options.digits)
 
     # cdigits cannot have higher precision, limit to digits
@@ -3645,9 +3617,6 @@ _option_group_optimization.add_option("-p", "--set-precision",
 _option_group_optimization.add_option("-c", "--set-c-precision",
                                       action="store", type=int, dest="cdigits", default=-1, metavar="NUM",
                                       help="set no. of sig. digits (path [c/s] control points) (default: %default)")
-_option_group_optimization.add_option("-k", "--keep-int-precision",
-                                      action="store_true", dest="keep_int_precision", default=False,
-                                      help="keep all digits left of decimal point regardless of set precision")
 _option_group_optimization.add_option("--disable-simplify-colors",
                                       action="store_false", dest="simple_colors", default=True,
                                       help="won't convert all colors to #RRGGBB format")

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3299,7 +3299,6 @@ def scourString(in_string, options=None):
     else:
         scouringContextC = scouringContext
 
-
     # globals for tracking statistics
     # TODO: get rid of these globals...
     global _num_elements_removed

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2640,12 +2640,11 @@ def scourUnitlessLength(length, needsRendererWorkaround=False, isControlPoint=Fa
         if(scouringKeepIntPrecision):
             length_as_int = int(round(length))
             len_length_as_int = len(str(abs(length_as_int)))
-            saved_prec = sContext.prec
             if(sContext.prec < len_length_as_int):
+                length = getcontext().create_decimal(str(int(round(length))))
+            else:
                 # preserve all digits left of the decimal point
-                sContext.prec = len_length_as_int
-            length = sContext.plus(length)
-            sContext.prec = saved_prec
+                length = sContext.plus(length)
         else:
             length = sContext.plus(length)
 
@@ -3290,6 +3289,10 @@ def scourString(in_string, options=None):
     scouringRoundNearZeroC = False
     # must have at least 1 significant digit
     # interrept digits == 0 as rounding to nearest int for values between -1 and 1
+    if(options.cdigits < 0):
+        # cdigits is negative value so use digits instead
+        options.cdigits = options.digits
+
     if(options.digits == 0):
         options.digits = 1
         scouringRoundNearZero = True
@@ -3297,6 +3300,8 @@ def scourString(in_string, options=None):
         options.cdigits = 1
         scouringRoundNearZeroC = True
     scouringContext = Context(prec=options.digits)
+
+    # cdigits cannot have higher precision, limit to digits
     if(options.cdigits < options.digits):
         scouringContextC = Context(prec=options.cdigits)
     else:
@@ -3632,7 +3637,7 @@ _option_group_optimization.add_option("-p", "--set-precision",
                                       action="store", type=int, dest="digits", default=5, metavar="NUM",
                                       help="set number of significant digits (default: %default)")
 _option_group_optimization.add_option("-c", "--set-c-precision",
-                                      action="store", type=int, dest="cdigits", default=5, metavar="NUM",
+                                      action="store", type=int, dest="cdigits", default=-1, metavar="NUM",
                                       help="set no. of sig. digits (path [c/s] control points) (default: %default)")
 _option_group_optimization.add_option("-k", "--keep-int-precision",
                                       action="store_true", dest="keep_int_precision", default=False,
@@ -3749,8 +3754,6 @@ def parse_args(args=None, ignore_additional_args=False):
             _options_parser.error("Additional arguments not handled: %r, see --help" % rargs)
     if options.digits < 0:
         _options_parser.error("Can't have negative significant digits, see --help")
-    if options.cdigits < 0:
-        _options_parser.error("Can't have negative significant digits for curve control points , see --help")
     if options.indent_type not in ['tab', 'space', 'none']:
         _options_parser.error("Invalid value for --indent, see --help")
     if options.indent_depth < 0:

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2568,7 +2568,9 @@ def scourCoordinates(data, options, forceCommaWsp=False, cmd=''):
         previousCoord = ''
         for coord in data:
             cp = ((cmd == 'c' and (c % 6) < 4) or (cmd == 's' and (c % 4) < 2))
-            scouredCoord = scourUnitlessLength(coord, needsRendererWorkaround=options.renderer_workaround, isControlPoint=cp)
+            scouredCoord = scourUnitlessLength(coord,
+                                               needsRendererWorkaround=options.renderer_workaround,
+                                               isControlPoint=cp)
             # only need the comma if the current number starts with a digit
             # (numbers can start with - without needing a comma before)
             # or if forceCommaWsp is True

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2567,7 +2567,8 @@ def scourCoordinates(data, options, forceCommaWsp=False, cmd=''):
         c = 0
         previousCoord = ''
         for coord in data:
-            scouredCoord = scourUnitlessLength(coord, needsRendererWorkaround=options.renderer_workaround, isControlPoint=((cmd == 'c' and (c % 6) < 4) or (cmd == 's' and (c % 4) < 2)))
+            cp = ((cmd == 'c' and (c % 6) < 4) or (cmd == 's' and (c % 4) < 2))
+            scouredCoord = scourUnitlessLength(coord, needsRendererWorkaround=options.renderer_workaround, isControlPoint=cp)
             # only need the comma if the current number starts with a digit
             # (numbers can start with - without needing a comma before)
             # or if forceCommaWsp is True
@@ -2625,26 +2626,26 @@ def scourUnitlessLength(length, needsRendererWorkaround=False, isControlPoint=Fa
 
     # reduce numeric precision
     # plus() corresponds to the unary prefix plus operator and applies context precision and rounding
-    sContext = scouringContext;
+    sContext = scouringContext
     roundNearZero = scouringRoundNearZero
     if(isControlPoint):
-       sContext = scouringContextC;
-       roundNearZero = scouringRoundNearZeroC;
+        sContext = scouringContextC
+        roundNearZero = scouringRoundNearZeroC
 
     if(roundNearZero and length > -1 and length < 1):
-       length = getcontext().create_decimal(str(int(round(length))))
+        length = getcontext().create_decimal(str(int(round(length))))
     else:
-       if(scouringKeepIntPrecision):
-          length_as_int = int(round(length))
-          len_length_as_int = len(str(abs(length_as_int)))
-          saved_prec = sContext.prec;
-          if(sContext.prec < len_length_as_int):
-             # preserve all digits left of the decimal point
-             sContext.prec = len_length_as_int;
-          length = sContext.plus(length)
-          sContext.prec = saved_prec;
-       else:
-          length = sContext.plus(length)
+        if(scouringKeepIntPrecision):
+            length_as_int = int(round(length))
+            len_length_as_int = len(str(abs(length_as_int)))
+            saved_prec = sContext.prec
+            if(sContext.prec < len_length_as_int):
+                # preserve all digits left of the decimal point
+                sContext.prec = len_length_as_int
+            length = sContext.plus(length)
+            sContext.prec = saved_prec
+        else:
+            length = sContext.plus(length)
 
     # remove trailing zeroes as we do not care for significance
     intLength = length.to_integral_value()

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3631,10 +3631,10 @@ _option_group_optimization.add_option("-p", "--set-precision",
                                       help="set number of significant digits (default: %default)")
 _option_group_optimization.add_option("-c", "--set-c-precision",
                                       action="store", type=int, dest="cdigits", default=5, metavar="NUM",
-                                      help="set number of significant digits for curve control points (default: %default)")
+                                      help="set no. of sig. digits (path [c/s] control points) (default: %default)")
 _option_group_optimization.add_option("-k", "--keep-int-precision",
                                       action="store_true", dest="keep_int_precision", default=False,
-                                      help="preserves all digits left of decimal point regardless of set precision")
+                                      help="keep all digits left of decimal point regardless of set precision")
 _option_group_optimization.add_option("--disable-simplify-colors",
                                       action="store_false", dest="simple_colors", default=True,
                                       help="won't convert all colors to #RRGGBB format")


### PR DESCRIPTION
Add a seperate precision option for curve control points
(--set-c-precision) . Interpret precision digits = 0 as round to nearest
integer between -1 and 1. Add option to preserves all digits left of
decimal point regardless of set precision.