### PR TITLE
Consolidate the code for serializing attributes

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3215,25 +3215,11 @@ def serializeXML(element, options, ind=0, preserveWhitespace=False):
 
     outParts.extend([(I * ind), '<', element.nodeName])
 
-    # always serialize the id or xml:id attributes first
-    if element.getAttribute('id') != '':
-        id = element.getAttribute('id')
-        quot = '"'
-        if id.find('"') != -1:
-            quot = "'"
-        outParts.extend([' id=', quot, id, quot])
-    if element.getAttribute('xml:id') != '':
-        id = element.getAttribute('xml:id')
-        quot = '"'
-        if id.find('"') != -1:
-            quot = "'"
-        outParts.extend([' xml:id=', quot, id, quot])
-
     # now serialize the other attributes
     known_attr = [
         # TODO: Maybe update with full list from https://www.w3.org/TR/SVG/attindex.html
         # (but should be kept inuitively ordered)
-        'id', 'class',
+        'id', 'xml:id', 'class',
         'transform',
         'x', 'y', 'z', 'width', 'height', 'x1', 'x2', 'y1', 'y2',
         'dx', 'dy', 'rotate', 'startOffset', 'method', 'spacing',
@@ -3253,8 +3239,6 @@ def serializeXML(element, options, ind=0, preserveWhitespace=False):
     attrIndices += [attrName2Index[name] for name in sorted(attrName2Index.keys())]
     for index in attrIndices:
         attr = attrList.item(index)
-        if attr.nodeName == 'id' or attr.nodeName == 'xml:id':
-            continue
         # if the attribute value contains a double-quote, use single-quotes
         quot = '"'
         if attr.nodeValue.find('"') != -1:

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3282,9 +3282,12 @@ def serializeXML(element, options, ind=0, preserveWhitespace=False):
             elif attrValue == 'default':
                 preserveWhitespace = False
 
-    # if no children, self-close
     children = element.childNodes
-    if children.length > 0:
+    if children.length == 0:
+        outParts.append('/>')
+        if indent > 0:
+            outParts.append(newline)
+    else:
         outParts.append('>')
 
         onNewLine = False
@@ -3317,10 +3320,6 @@ def serializeXML(element, options, ind=0, preserveWhitespace=False):
         if onNewLine:
             outParts.append(I * ind)
         outParts.extend(['</', element.nodeName, '>'])
-        if indent > 0:
-            outParts.append(newline)
-    else:
-        outParts.append('/>')
         if indent > 0:
             outParts.append(newline)
 


### PR DESCRIPTION
The attributes `id` and `xml:id` have been handled specially, though there has been little advantage in doing so. After merging this pull request, the same code will be used to handle every attribute.