### PR TITLE
Fix regression with regard to quotes in attribute values

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3178,21 +3178,23 @@ def remapNamespacePrefix(node, oldprefix, newprefix):
         remapNamespacePrefix(child, oldprefix, newprefix)
 
 
-def makeWellFormed(str):
-    # Don't escape quotation marks for now as they are fine in text nodes
-    # as well as in attributes if used reciprocally
-    #     xml_ents = { '<':'&lt;', '>':'&gt;', '&':'&amp;', "'":'&apos;', '"':'&quot;'}
+def makeWellFormed(str, quote=''):
     xml_ents = {'<': '&lt;', '>': '&gt;', '&': '&amp;'}
-
-#  starr = []
-#  for c in str:
-#      if c in xml_ents:
-#          starr.append(xml_ents[c])
-#      else:
-#          starr.append(c)
-
-    # this list comprehension is short-form for the above for-loop:
+    if quote:
+        xml_ents[quote] = '&apos;' if (quote == "'") else "&quot;"
     return ''.join([xml_ents[c] if c in xml_ents else c for c in str])
+
+
+def chooseQuoteCharacter(str):
+    quotCount = str.count('"')
+    aposCount = str.count("'")
+    if quotCount > aposCount:
+        quote = "'"
+        hasEmbeddedQuote = aposCount
+    else:
+        quote = '"'
+        hasEmbeddedQuote = quotCount
+    return (quote, hasEmbeddedQuote)
 
 
 # hand-rolled serialization function that has the following benefits:
@@ -3239,12 +3241,11 @@ def serializeXML(element, options, ind=0, preserveWhitespace=False):
     attrIndices += [attrName2Index[name] for name in sorted(attrName2Index.keys())]
     for index in attrIndices:
         attr = attrList.item(index)
-        # if the attribute value contains a double-quote, use single-quotes
-        quot = '"'
-        if attr.nodeValue.find('"') != -1:
-            quot = "'"
 
-        attrValue = makeWellFormed(attr.nodeValue)
+        attrValue = attr.nodeValue
+        (quote, hasEmbeddedQuote) = chooseQuoteCharacter(attrValue)
+        attrValue = makeWellFormed(attrValue, quote if hasEmbeddedQuote else '')
+
         if attr.nodeName == 'style':
             # sort declarations
             attrValue = ';'.join([p for p in sorted(attrValue.split(';'))])
@@ -3258,7 +3259,7 @@ def serializeXML(element, options, ind=0, preserveWhitespace=False):
                 outParts.append('xmlns:')
             elif attr.namespaceURI == 'http://www.w3.org/1999/xlink':
                 outParts.append('xlink:')
-        outParts.extend([attr.localName, '=', quot, attrValue, quot])
+        outParts.extend([attr.localName, '=', quote, attrValue, quote])
 
         if attr.nodeName == 'xml:space':
             if attrValue == 'preserve':

--- a/testscour.py
+++ b/testscour.py
@@ -1818,6 +1818,17 @@ class HandleQuotesInAttributes(unittest.TestCase):
                         'Failed on attribute value with the same number of double quotes as single quotes')
 
 
+class PreserveQuotesInStyles(unittest.TestCase):
+
+    def runTest(self):
+        with open('unittests/quotes-in-styles.svg', "rb") as f:
+            output = scourString(f.read())
+        self.assertTrue('use[id="t"]' in output,
+                        'Failed to preserve quote characters in a style element')
+        self.assertTrue("'Times New Roman'" in output,
+                        'Failed to preserve quote characters in a style attribute')
+
+
 class DoNotStripCommentsOutsideOfRoot(unittest.TestCase):
 
     def runTest(self):

--- a/testscour.py
+++ b/testscour.py
@@ -1779,7 +1779,43 @@ class XmlEntities(unittest.TestCase):
 
     def runTest(self):
         self.assertEqual(makeWellFormed('<>&'), '&lt;&gt;&amp;',
-                         'Incorrectly translated XML entities')
+                         'Incorrectly translated unquoted XML entities')
+        self.assertEqual(makeWellFormed('<>&', "'"), '&lt;&gt;&amp;',
+                         'Incorrectly translated single-quoted XML entities')
+        self.assertEqual(makeWellFormed('<>&', '"'), '&lt;&gt;&amp;',
+                         'Incorrectly translated double-quoted XML entities')
+
+        self.assertEqual(makeWellFormed("'"), "'",
+                         'Incorrectly translated unquoted single quote')
+        self.assertEqual(makeWellFormed('"'), '"',
+                         'Incorrectly translated unquoted double quote')
+
+        self.assertEqual(makeWellFormed("'", '"'), "'",
+                         'Incorrectly translated double-quoted single quote')
+        self.assertEqual(makeWellFormed('"', "'"), '"',
+                         'Incorrectly translated single-quoted double quote')
+
+        self.assertEqual(makeWellFormed("'", "'"), '&apos;',
+                         'Incorrectly translated single-quoted single quote')
+        self.assertEqual(makeWellFormed('"', '"'), '&quot;',
+                         'Incorrectly translated double-quoted double quote')
+
+
+class HandleQuotesInAttributes(unittest.TestCase):
+
+    def runTest(self):
+        with open('unittests/entities.svg', "rb") as f:
+            output = scourString(f.read())
+        self.assertTrue('a="\'"' in output,
+                        'Failed on attribute value with non-double quote')
+        self.assertTrue("b='\"'" in output,
+                        'Failed on attribute value with non-single quote')
+        self.assertTrue("c=\"''&quot;\"" in output,
+                        'Failed on attribute value with more single quotes than double quotes')
+        self.assertTrue('d=\'""&apos;\'' in output,
+                        'Failed on attribute value with more double quotes than single quotes')
+        self.assertTrue("e=\"''&quot;&quot;\"" in output,
+                        'Failed on attribute value with the same number of double quotes as single quotes')
 
 
 class DoNotStripCommentsOutsideOfRoot(unittest.TestCase):

--- a/unittests/entities.svg
+++ b/unittests/entities.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+ a="'"
+ b='"'
+ c="''&quot;"
+ d='""&apos;'
+ e='&apos;&apos;""'
+/>

--- a/unittests/quotes-in-styles.svg
+++ b/unittests/quotes-in-styles.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+ <style>use[id="t"] {font-size: small}</style>
+ <text id="t" style="font-family:'Times New Roman'"/>
+</svg>


### PR DESCRIPTION
The following commit removed the escaping of single quotes and double quotes, in order to fix issues #21 and #56:

&nbsp;&nbsp;&nbsp;&nbsp;**commit** 57f93efc894b1ba4c30e42b549b0081185029c36  
&nbsp;&nbsp;&nbsp;&nbsp;**Date:** Tue Aug 16 00:10:41 2016 +0200

However, this broke the quoting of an attribute value that has both a single quote and a double quote (see below for an example). This patch series re-introduces the escaping of quotes, but ultimately uses entities only when both a single quote and a double quote are present at the same time in an attribute value; whether single quotes or double quotes are escaped depends on which choice produces the shortest result. Unit tests are included.

-------------

The following presents a concrete, real-world example of the problem that is being fixed by this pull request.

    $ file='https://upload.wikimedia.org/wikipedia/commons/archive/a/a5/20170825000948%21Example_of_an_iterative_DNS_resolver.svg'
    $ curl "$file" >a.svg
    $ inkscape a.svg

In `inkscape`, select the text object that reads:

    "Where's www.wikipedia.org?"

Convert it to a path object (`Path > Object to Path`, or press `Shift+Ctrl+C`); next, save the file as `b.svg`, making sure to choose as the file type `Optimized SVG (*.svg)`. Then:

    $ grep -n Where b.svg
    43:  <g aria-label='"Where's www.wikipedia.org?"'>

Clearly, line 43 is wrong; you can check whether it's well formed, using a tool from the [expat](http://expat.sourceforge.net/) project:

    $ xmlwf b.svg
    b.svg:43:24: not well-formed (invalid token)
    $ sed -n -e '43{p;q;}' b.svg | cut -c 24-
    's www.wikipedia.org?"'>

Indeed, try opening the `b.svg` in a browser; `firefox 55.0.1` produces the following output (it even identifies a better character for the start of the error):

    XML Parsing Error: not well-formed
    Location: file:///tmp/b.svg
    Line Number 43, Column 25:
    
      <g aria-label='"Where's www.wikipedia.org?"'>
    ------------------------^

The browser of `Chrome OS 59.0.3071.134` produces:

    This page contains the following errors:
    
    error on line 43 at column 25: attributes construct error

    Below is a rendering of the page up to the first error.

This pull request fixes the problem.