### PR TITLE
Optimize find referenced elements

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -641,11 +641,14 @@ def findReferencingProperty(node, prop, val, ids):
                     ids[id] = [1, [node]]
 
 
-def removeUnusedDefs(doc, defElem, elemsToRemove=None):
+def removeUnusedDefs(doc, defElem, elemsToRemove=None, referencedIDs=None):
     if elemsToRemove is None:
         elemsToRemove = []
 
-    referencedIDs = findReferencedElements(doc.documentElement)
+    # removeUnusedDefs do not change the XML itself; therefore there is no point in
+    # recomputing findReferencedElements when we recurse into child nodes.
+    if referencedIDs is None:
+        referencedIDs = findReferencedElements(doc.documentElement)
 
     keepTags = ['font', 'style', 'metadata', 'script', 'title', 'desc']
     for elem in defElem.childNodes:
@@ -655,7 +658,7 @@ def removeUnusedDefs(doc, defElem, elemsToRemove=None):
             # we only inspect the children of a group in a defs if the group
             # is not referenced anywhere else
             if elem.nodeName == 'g' and elem.namespaceURI == NS['SVG']:
-                elemsToRemove = removeUnusedDefs(doc, elem, elemsToRemove)
+                elemsToRemove = removeUnusedDefs(doc, elem, elemsToRemove, referencedIDs=referencedIDs)
             # we only remove if it is not one of our tags we always keep (see above)
             elif elem.nodeName not in keepTags:
                 elemsToRemove.append(elem)

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -593,8 +593,6 @@ def findReferencedElements(node, ids=None):
 
     # now get all style properties and the fill, stroke, filter attributes
     styles = node.getAttribute('style').split(';')
-    for attr in referencingProps:
-        styles.append(':'.join([attr, node.getAttribute(attr)]))
 
     for style in styles:
         propval = style.split(':')
@@ -602,6 +600,12 @@ def findReferencedElements(node, ids=None):
             prop = propval[0].strip()
             val = propval[1].strip()
             findReferencingProperty(node, prop, val, ids)
+
+    for attr in referencingProps:
+        val = node.getAttribute(attr).strip()
+        if not val:
+            continue
+        findReferencingProperty(node, attr, val, ids)
 
     if node.hasChildNodes():
         for child in node.childNodes:


### PR DESCRIPTION
The biggest win (at least in my test case) is the "findReferencedElements: Handle referencingProps separately", which avoids a large number of unnecessary string operations.

But there is also a large potential in "Avoid recomputing findReferencedElements in removeUnusedDefs" for any SVG that need a number of calls to "removeUnreferencedElements" or where "removeUnusedDefs" recurses a lot of times.  My particular test case does not seem to trigger any of that though (with a total of one call to removeUnreferencedElements)