### PR TITLE
Additional optimizations

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -561,53 +561,55 @@ def findReferencedElements(node, ids=None):
     global referencingProps
     if ids is None:
         ids = {}
-    # TODO: input argument ids is clunky here (see below how it is called)
-    # GZ: alternative to passing dict, use **kwargs
 
-    # if this node is a style element, parse its text into CSS
-    if node.nodeName == 'style' and node.namespaceURI == NS['SVG']:
-        # one stretch of text, please! (we could use node.normalize(), but
-        # this actually modifies the node, and we don't want to keep
-        # whitespace around if there's any)
-        stylesheet = "".join([child.nodeValue for child in node.childNodes])
-        if stylesheet != '':
-            cssRules = parseCssString(stylesheet)
-            for rule in cssRules:
-                for propname in rule['properties']:
-                    propval = rule['properties'][propname]
-                    findReferencingProperty(node, propname, propval, ids)
-        return ids
+    if 1:  # Indent-only
+        # TODO: input argument ids is clunky here (see below how it is called)
+        # GZ: alternative to passing dict, use **kwargs
 
-    # else if xlink:href is set, then grab the id
-    href = node.getAttributeNS(NS['XLINK'], 'href')
-    if href != '' and len(href) > 1 and href[0] == '#':
-        # we remove the hash mark from the beginning of the id
-        id = href[1:]
-        if id in ids:
-            ids[id].append(node)
-        else:
-            ids[id] = [node]
+        # if this node is a style element, parse its text into CSS
+        if node.nodeName == 'style' and node.namespaceURI == NS['SVG']:
+            # one stretch of text, please! (we could use node.normalize(), but
+            # this actually modifies the node, and we don't want to keep
+            # whitespace around if there's any)
+            stylesheet = "".join([child.nodeValue for child in node.childNodes])
+            if stylesheet != '':
+                cssRules = parseCssString(stylesheet)
+                for rule in cssRules:
+                    for propname in rule['properties']:
+                        propval = rule['properties'][propname]
+                        findReferencingProperty(node, propname, propval, ids)
+            return ids
 
-    # now get all style properties and the fill, stroke, filter attributes
-    styles = node.getAttribute('style').split(';')
+        # else if xlink:href is set, then grab the id
+        href = node.getAttributeNS(NS['XLINK'], 'href')
+        if href != '' and len(href) > 1 and href[0] == '#':
+            # we remove the hash mark from the beginning of the id
+            id = href[1:]
+            if id in ids:
+                ids[id].append(node)
+            else:
+                ids[id] = [node]
 
-    for style in styles:
-        propval = style.split(':')
-        if len(propval) == 2:
-            prop = propval[0].strip()
-            val = propval[1].strip()
-            findReferencingProperty(node, prop, val, ids)
+        # now get all style properties and the fill, stroke, filter attributes
+        styles = node.getAttribute('style').split(';')
 
-    for attr in referencingProps:
-        val = node.getAttribute(attr).strip()
-        if not val:
-            continue
-        findReferencingProperty(node, attr, val, ids)
+        for style in styles:
+            propval = style.split(':')
+            if len(propval) == 2:
+                prop = propval[0].strip()
+                val = propval[1].strip()
+                findReferencingProperty(node, prop, val, ids)
 
-    if node.hasChildNodes():
-        for child in node.childNodes:
-            if child.nodeType == Node.ELEMENT_NODE:
-                findReferencedElements(child, ids)
+        for attr in referencingProps:
+            val = node.getAttribute(attr).strip()
+            if not val:
+                continue
+            findReferencingProperty(node, attr, val, ids)
+
+        if node.hasChildNodes():
+            for child in node.childNodes:
+                if child.nodeType == Node.ELEMENT_NODE:
+                    findReferencedElements(child, ids)
     return ids
 
 

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -549,20 +549,23 @@ def findElementsWithId(node, elems=None):
 referencingProps = ['fill', 'stroke', 'filter', 'clip-path', 'mask',  'marker-start', 'marker-end', 'marker-mid']
 
 
-def findReferencedElements(node, ids=None):
+def findReferencedElements(start_node):
     """
     Returns IDs of all referenced elements
-    - node is the node at which to start the search.
+    - start_node is the node at which to start the search.
     - returns a map which has the id as key and
       each value is is a list of nodes
 
     Currently looks at 'xlink:href' and all attributes in 'referencingProps'
     """
     global referencingProps
-    if ids is None:
-        ids = {}
+    ids = {}
 
-    if 1:  # Indent-only
+    # Search all nodes in depth-first search
+    stack = [start_node]
+
+    while stack:
+        node = stack.pop()
         # TODO: input argument ids is clunky here (see below how it is called)
         # GZ: alternative to passing dict, use **kwargs
 
@@ -578,7 +581,7 @@ def findReferencedElements(node, ids=None):
                     for propname in rule['properties']:
                         propval = rule['properties'][propname]
                         findReferencingProperty(node, propname, propval, ids)
-            return ids
+            continue
 
         # else if xlink:href is set, then grab the id
         href = node.getAttributeNS(NS['XLINK'], 'href')
@@ -607,9 +610,8 @@ def findReferencedElements(node, ids=None):
             findReferencingProperty(node, attr, val, ids)
 
         if node.hasChildNodes():
-            for child in node.childNodes:
-                if child.nodeType == Node.ELEMENT_NODE:
-                    findReferencedElements(child, ids)
+            stack.extend(n for n in node.childNodes if n.nodeType == Node.ELEMENT_NODE)
+
     return ids
 
 


### PR DESCRIPTION
The primary commit here is "Attempt to reuse results from findReferencedElements better", which reduces runtime for me by about 6%.  It does so by attempting to avoid calling findReferenceElements as it is the most expensive function there is.  In my case, it reduced the number of calls from 8 to 6 on the root element.

The next two commits rewrite findReferencedElements to an "iterative" variant.  In itself, it does not give anything measurable.  However, with those applied, it is a lot easier to tell how many times we call findReferenceElements on the root element (as it is now just the number of calls to findReferenceElements).

The last patch simply inlines a loop to remove some call overhead in python.  It is not particular measurable, but it does remove the function from the top 3 in the "ncalls" column from profiling.  With this, none of the scour.py functions appear in the top 15 of "ncalls" on my sample svg.