### PR TITLE
Remove an unnecessary loop

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3471,11 +3471,9 @@ def scourString(in_string, options=None):
                 _num_elements_removed += 1
 
     if options.strip_ids:
-        bContinueLooping = True
-        while bContinueLooping:
-            identifiedElements = unprotected_ids(doc, options)
-            referencedIDs = findReferencedElements(doc.documentElement)
-            bContinueLooping = (removeUnreferencedIDs(referencedIDs, identifiedElements) > 0)
+        referencedIDs = findReferencedElements(doc.documentElement)
+        identifiedElements = unprotected_ids(doc, options)
+        removeUnreferencedIDs(referencedIDs, identifiedElements)
 
     while removeDuplicateGradientStops(doc) > 0:
         pass


### PR DESCRIPTION
The unprotected_ids function returns all unprotected ids and
removeUnreferencedIDs removes all of them that does not appear in the
return value of findReferencedElements.

On closer observation it turns out that removeUnreferencedIDs cannot
cause nodes/IDs to become unprotected nor unreferenced (as it only
remove the "id" attribute, not the node).  With this in mind, we can
just remove the loop and save a call to all of these functions.

Signed-off-by: Niels Thykier <niels@thykier.net>