### PR TITLE
Avoid O(n²) in removeDuplicateGradient

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1375,7 +1375,7 @@ def computeGradientBucketKey(grad):
                 stopKey = stop.getAttribute(attr)
                 subKeys.append(stopKey)
 
-    # Use a raw ASCII "record seperator" control character as it is
+    # Use a raw ASCII "record separator" control character as it is
     # not likely to be used in any of these values (without having to
     # be escaped).
     return "\x1e".join(subKeys)


### PR DESCRIPTION
The original implementation of removeDuplicateGradient does O(n²)
search over all gradients to remove duplicates.  In images with many
gradients (such as [MediaWiki_logo_1.svg]), this becomes a significant
overhead as that logo has over 900 duplicated gradients.

We solve this by creating a key for each gradient based on the
attributes we use for duplication detection.  This key is generated
such that if two gradients have the same key, they are duplicates (for
our purpose) and the keys are different then the gradients are
guaranteed to be different as well.  With such a key, we can rely on a
dict to handle the duplication detection (which it does very well).

This change improves the runtime performance on [MediaWiki_logo_1.svg]
by about 25% (8m51s -> 1m56s on 5 runs).

Original:
    $ time for I in $(seq 1 5) ; do \
        PYTHONPATH=. python3 -m scour.scour MediaWiki_logo_1.svg out.svg ; \
      done
    Scour processed file "heavy.svg" in 105042 ms: 1582746/4989544 bytes new/orig -> 31.7%
    Scour processed file "heavy.svg" in 103412 ms: 1582746/4989544 bytes new/orig -> 31.7%
    Scour processed file "heavy.svg" in 105334 ms: 1582746/4989544 bytes new/orig -> 31.7%
    Scour processed file "heavy.svg" in 107902 ms: 1582746/4989544 bytes new/orig -> 31.7%
    Scour processed file "heavy.svg" in 108161 ms: 1582746/4989544 bytes new/orig -> 31.7%

    8m51.855s
    ...

Optimized:
    $ time for I in $(seq 1 5) ; do \
        PYTHONPATH=. python3 -m scour.scour MediaWiki_logo_1.svg out.svg ; \
      done
    Scour processed file "heavy.svg" in 21559 ms: 1582746/4989544 bytes new/orig -> 31.7%
    Scour processed file "heavy.svg" in 21936 ms: 1582746/4989544 bytes new/orig -> 31.7%
    Scour processed file "heavy.svg" in 21540 ms: 1582746/4989544 bytes new/orig -> 31.7%
    Scour processed file "heavy.svg" in 21518 ms: 1582746/4989544 bytes new/orig -> 31.7%
    Scour processed file "heavy.svg" in 21664 ms: 1582746/4989544 bytes new/orig -> 31.7%

    real    1m56.400s
    ...

[MediaWiki_logo_1.svg]: https://upload.wikimedia.org/wikipedia/commons/archive/5/54/20120822053933%21MediaWiki_logo_1.svg

Signed-off-by: Niels Thykier <niels@thykier.net>