### PR TITLE
Use time.perf_counter when available

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -74,11 +74,10 @@ VER = __version__
 COPYRIGHT = u'Copyright Jeff Schiller, Louis Simard, 2010'
 
 
-# select the most precise walltime measurement function available on the platform
-if sys.platform.startswith('win'):
-    walltime = time.clock
-else:
-    walltime = time.time
+# the walltime measurement function, we will use for reporting
+# reporting how long it took to process a given SVG file.  For our
+# purposes, the time.time() function has sufficent accuracy.
+walltime = time.time
 
 
 NS = {'SVG':      'http://www.w3.org/2000/svg',


### PR DESCRIPTION
As of python3.3, the recommended method for obtaining a performance
timer is no longer "time.clock()" but "time.perf_counter()".  By using
time.perf_counter, we outsource the problem for finding the best
performance messaurement to python.  Plus, we also avoid inaccurate
timings if the system time is changed during the processing of the SVG
image on platforms where we used to use "time.time()".

For python2 and python3 before 3.3, we still have to use the original
timers.

Signed-off-by: Niels Thykier <niels@thykier.net>