### PR TITLE
Correct handling of "m0 0" vs. "z" commands

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2190,14 +2190,15 @@ def cleanPath(element, options):
             i = 0
             if cmd in ['m', 'l', 't']:
                 if cmd == 'm':
-                    # remove m0,0 segments
-                    if pathIndex > 0 and data[0] == data[i + 1] == 0:
-                        # 'm0,0 x,y' can be replaces with 'lx,y',
-                        # except the first m which is a required absolute moveto
-                        path[pathIndex] = ('l', data[2:])
-                        _num_path_segments_removed += 1
-                    else:  # else skip move coordinate
-                        i = 2
+                    # It might be tempting to rewrite "m0 0 ..." into
+                    # "l..." here.  However, this is an unsound
+                    # optimization in general as "m0 0 ... z" is
+                    # different from "l...z".
+                    #
+                    # To do such a rewrite, we need to understand the
+                    # full subpath, so for now just leave the first
+                    # two coordinates of "m" alone.
+                    i = 2
                 while i < len(data):
                     if data[i] == data[i + 1] == 0:
                         del data[i:i + 2]

--- a/testscour.py
+++ b/testscour.py
@@ -2058,8 +2058,9 @@ class PathEmptyMove(unittest.TestCase):
 
     def runTest(self):
         doc = scourXmlFile('unittests/path-empty-move.svg')
-        self.assertEqual(doc.getElementsByTagName('path')[0].getAttribute('d'), 'm100 100 200 100z')
-        self.assertEqual(doc.getElementsByTagName('path')[1].getAttribute('d'), 'm100 100v200l100 100z')
+        # This path can actually be optimized to avoid the "m0 0z".
+        self.assertEqual(doc.getElementsByTagName('path')[0].getAttribute('d'), 'm100 100 200 100m0 0z')
+        self.assertEqual(doc.getElementsByTagName('path')[1].getAttribute('d'), 'm100 100v200m0 0 100 100z')
 
 
 class DefaultsRemovalToplevel(unittest.TestCase):

--- a/testscour.py
+++ b/testscour.py
@@ -2054,13 +2054,25 @@ class StyleToAttr(unittest.TestCase):
         self.assertEqual(line.getAttribute('marker-end'), 'url(#m)')
 
 
-class PathEmptyMove(unittest.TestCase):
+class PathCommandRewrites(unittest.TestCase):
 
     def runTest(self):
-        doc = scourXmlFile('unittests/path-empty-move.svg')
-        # This path can actually be optimized to avoid the "m0 0z".
-        self.assertEqual(doc.getElementsByTagName('path')[0].getAttribute('d'), 'm100 100 200 100m0 0z')
-        self.assertEqual(doc.getElementsByTagName('path')[1].getAttribute('d'), 'm100 100v200m0 0 100 100z')
+        doc = scourXmlFile('unittests/path-command-rewrites.svg')
+        paths = doc.getElementsByTagName('path')
+        expected_paths = [
+            ('m100 100 200 100', "Trailing m0 0z not removed"),
+            ('m100 100v200m0 0 100 100z', "Mangled m0 0 100 100"),
+            ("m100 100v200m0 0 2-1-2 1z", "Should have removed empty m0 0"),
+            ("m100 100v200l3-5-5 3m0 0 2-1-2 1z", "Rewrite m0 0 3-5-5 3 ... -> l3-5-5 3 ..."),
+            ("m100 100v200m0 0 3-5-5 3zm0 0 2-1-2 1z", "No rewrite of m0 0 3-5-5 3z"),
+        ]
+        self.assertEqual(len(paths), len(expected_paths), "len(actual_paths) != len(expected_paths)")
+        for i in range(len(paths)):
+            actual_path = paths[i].getAttribute('d')
+            expected_path, message = expected_paths[i]
+            self.assertEqual(actual_path,
+                             expected_path,
+                             '%s: "%s" != "%s"' % (message, actual_path, expected_path))
 
 
 class DefaultsRemovalToplevel(unittest.TestCase):

--- a/unittests/path-command-rewrites.svg
+++ b/unittests/path-command-rewrites.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <path d="m100 100 l200 100 m0 0z" />
+  <path d="m100 100 v200 m0 0 100 100z" />
+  <path d="m100 100 v200 m0 0m0 0 2-1-2 1z" />
+  <path d="m100 100 v200 m0 0 3-5-5 3m0 0 2-1-2 1z" />
+  <path d="m100 100 v200 m0 0 3-5-5 3zm0 0 2-1-2 1z" />
+</svg>

--- a/unittests/path-empty-move.svg
+++ b/unittests/path-empty-move.svg
@@ -1,5 +1,0 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg">
-  <path d="m100 100 l200 100 m0 0z" />
-  <path d="m100 100 v200 m0 0 100 100z" />
-</svg>


### PR DESCRIPTION
As observed in #163, scour sometimes do some unsafe path rewrites.

This branch solves that issue by separating the logic for removing path segments from the logic for rewriting commands.  The first commit removes the current unsafe optimization and the next one reimplements it (and adds a few more test cases for path cleaning of commands).