### PR TITLE
Fix handling of boolean flags in elliptical path commands

### DIFF
--- a/scour/svg_regex.py
+++ b/scour/svg_regex.py
@@ -247,16 +247,24 @@ class SVGPathParser(object):
             axis_rotation = Decimal(token[1]) * 1
 
             token = next_val_fn()
-            if token[1] not in ('0', '1'):
+            if token[1][0] not in ('0', '1'):
                 raise SyntaxError("expecting a boolean flag; got %r" % (token,))
-            large_arc_flag = Decimal(token[1]) * 1
+            large_arc_flag = Decimal(token[1][0]) * 1
 
-            token = next_val_fn()
-            if token[1] not in ('0', '1'):
+            if len(token[1]) > 1:
+                token = list(token)
+                token[1] = token[1][1:]
+            else:
+                token = next_val_fn()
+            if token[1][0] not in ('0', '1'):
                 raise SyntaxError("expecting a boolean flag; got %r" % (token,))
-            sweep_flag = Decimal(token[1]) * 1
+            sweep_flag = Decimal(token[1][0]) * 1
 
-            token = next_val_fn()
+            if len(token[1]) > 1:
+                token = list(token)
+                token[1] = token[1][1:]
+            else:
+                token = next_val_fn()
             if token[0] not in self.number_tokens:
                 raise SyntaxError("expecting a number; got %r" % (token,))
             x = Decimal(token[1]) * 1

--- a/testscour.py
+++ b/testscour.py
@@ -1101,6 +1101,24 @@ class ChangeQuadToShorthandInPath(unittest.TestCase):
                          'Did not change quadratic curves into shorthand curve segments in path')
 
 
+class BooleanFlagsInEllipticalPath(unittest.TestCase):
+
+    def test_omit_spaces(self):
+        doc = scourXmlFile('unittests/path-elliptical-flags.svg', parse_args(['--no-renderer-workaround']))
+        paths = doc.getElementsByTagNameNS(SVGNS, 'path')
+        for path in paths:
+            self.assertEqual(path.getAttribute('d'), 'm0 0a100 50 0 00100 50',
+                             'Did not ommit spaces after boolean flags in elliptical arg path command')
+
+    def test_output_spaces_with_renderer_workaround(self):
+        doc = scourXmlFile('unittests/path-elliptical-flags.svg', parse_args(['--renderer-workaround']))
+        paths = doc.getElementsByTagNameNS(SVGNS, 'path')
+        for path in paths:
+            self.assertEqual(path.getAttribute('d'), 'm0 0a100 50 0 0 0 100 50',
+                             'Did not output spaces after boolean flags in elliptical arg path command '
+                             'with renderer workaround')
+
+
 class DoNotOptimzePathIfLarger(unittest.TestCase):
 
     def runTest(self):

--- a/unittests/path-elliptical-flags.svg
+++ b/unittests/path-elliptical-flags.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="-100 -50 300 150" xmlns="http://www.w3.org/2000/svg">
+ <path d="m0 0a100 50 0 0 0 100 50" fill="none" stroke="#000"/>
+ <path d="m0 0a100 50 0 0  0100 50" fill="none" stroke="green"/>
+ <path d="m0 0a100 50 0 00  100 50" fill="none" stroke="blue"/>
+ <path d="m0 0a100 50 0   00100 50" fill="none" stroke="red"/>
+</svg>


### PR DESCRIPTION
- properly parse paths without space after boolean flags (fixes #161)
- omit space after boolean flag to shave off a few bytes when not using renderer workarounds