### PR TITLE
Gh 184 perf faster remove default attr value

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1876,6 +1876,20 @@ default_attributes = [
     DefaultAttribute('yChannelSelector', 'A', elements='feDisplacementMap')
 ]
 
+default_attributes_restricted_by_tag = defaultdict(list)
+default_attributes_unrestricted = []
+
+for attr in default_attributes:
+    if attr.elements is None:
+        # Applies to all tags
+        default_attributes_unrestricted.append(attr)
+        continue
+    if type(attr.elements) is str:
+        default_attributes_restricted_by_tag[attr.elements].append(attr)
+    else:
+        for tag in attr.elements:
+            default_attributes_restricted_by_tag[tag].append(attr)
+
 
 def taint(taintedSet, taintedAttribute):
     u"""Adds an attribute to a set of attributes.

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1910,9 +1910,6 @@ def removeDefaultAttributeValue(node, attribute):
     if not node.hasAttribute(attribute.name):
         return 0
 
-    if (attribute.elements is not None) and (node.nodeName not in attribute.elements):
-        return 0
-
     # differentiate between text and numeric values
     if isinstance(attribute.value, str):
         if node.getAttribute(attribute.name) == attribute.value:
@@ -1941,9 +1938,17 @@ def removeDefaultAttributeValues(node, options, tainted=set()):
     if node.nodeType != Node.ELEMENT_NODE:
         return 0
 
-    # Conditionally remove all default attributes defined in 'default_attributes' (a list of 'DefaultAttribute's)
-    for attribute in default_attributes:
+    # Remove all default attributes.  The remoteDefaultAttributeValue
+    # function deals with "if/when" we are allowed to remove the
+    # attribute as long as we supply it only with attributes that are
+    # applicable for this given node.  That part is handled by using
+    # default_attributes_unrestricted and
+    # default_attributes_restricted_by_tag
+    for attribute in default_attributes_unrestricted:
         num += removeDefaultAttributeValue(node, attribute)
+    if node.nodeName in default_attributes_restricted_by_tag:
+        for attribute in default_attributes_restricted_by_tag[node.nodeName]:
+            num += removeDefaultAttributeValue(node, attribute)
 
     # Summarily get rid of default properties
     attributes = [node.attributes.item(i).nodeName for i in range(node.attributes.length)]


### PR DESCRIPTION
This reduces runtime by ~15-25% on the 1_42_polytope_7-cube.svg case provided in #184 (tested with python3).  Note that the runtime is still 5-6 minutes after this, so I would not consider #184 closed with just this commit.