### PR TITLE
Enable shortenIDs to recycle existing IDs

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -714,7 +714,7 @@ def shortenIDs(doc, prefix, options):
     # Add unreferenced IDs to end of idList in arbitrary order
     idList.extend([rid for rid in identifiedElements if rid not in idList])
     # Ensure we do not reuse a protected ID by accident
-    protectedIDs = _protectedIDs(identifiedElements, options)
+    protectedIDs = protected_ids(identifiedElements, options)
 
     curIdNum = 1
 
@@ -831,7 +831,7 @@ def renameID(doc, idFrom, idTo, identifiedElements, referencedIDs):
     return num
 
 
-def _protectedIDs(seenIDs, options):
+def protected_ids(seenIDs, options):
     """Return a list of protected IDs out of the seenIDs"""
     protectedIDs = []
     if options.protect_ids_prefix or options.protect_ids_noninkscape or options.protect_ids_list:
@@ -858,7 +858,7 @@ def _protectedIDs(seenIDs, options):
 def unprotected_ids(doc, options):
     u"""Returns a list of unprotected IDs within the document doc."""
     identifiedElements = findElementsWithId(doc.documentElement)
-    protectedIDs = _protectedIDs(identifiedElements, options)
+    protectedIDs = protected_ids(identifiedElements, options)
     if protectedIDs:
         for id in protectedIDs:
             del identifiedElements[id]

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -738,7 +738,7 @@ def shortenIDs(doc, prefix, options):
         # (e.g. remapping "c" to "a" is not going to win us anything)
         if len(curId) != len(rid):
             # Then go rename it.
-            num += renameID(doc, rid, curId, identifiedElements, referencedIDs.get(rid))
+            num += renameID(rid, curId, identifiedElements, referencedIDs.get(rid))
         elif curId < rid:
             # If we skip reassigning an ID because it has the same length
             # (E.g. skipping "c" -> "a"), then we have to mark the "future"
@@ -769,7 +769,7 @@ def intToID(idnum, prefix):
     return prefix + rid
 
 
-def renameID(doc, idFrom, idTo, identifiedElements, referringNodes):
+def renameID(idFrom, idTo, identifiedElements, referringNodes):
     """
     Changes the ID name from idFrom to idTo, on the declaring element
     as well as all nodes in referringNodes.

--- a/testscour.py
+++ b/testscour.py
@@ -1948,6 +1948,19 @@ class ShortenIDsOption(unittest.TestCase):
                          'Did not update reference to shortened ID')
 
 
+class ShortenIDsStableOutput(unittest.TestCase):
+
+    def runTest(self):
+        doc = scourXmlFile('unittests/shorten-ids-stable-output.svg',
+                           parse_args(['--shorten-ids']))
+        use_tags = doc.getElementsByTagName('use')
+        hrefs_ordered = [x.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
+                         for x in use_tags]
+        expected = ['#a', '#b', '#b']
+        self.assertEquals(hrefs_ordered, expected,
+                          '--shorten-ids pointlessly reassigned ids')
+
+
 class MustKeepGInSwitch(unittest.TestCase):
 
     def runTest(self):

--- a/unittests/shorten-ids-stable-output.svg
+++ b/unittests/shorten-ids-stable-output.svg
@@ -2,10 +2,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
  <defs>
   <rect id="a" width="80" height="50" fill="red"/>
-  <rect id="b" width="80" height="50" fill="blue"/>
+  <rect id="long_id" width="80" height="50" fill="blue"/>
  </defs>
  <use xlink:href="#a"/>
- <use xlink:href="#b"/>
- <use xlink:href="#b"/>
+ <use xlink:href="#long_id"/>
+ <use xlink:href="#long_id"/>
 </svg>
 

--- a/unittests/shorten-ids-stable-output.svg
+++ b/unittests/shorten-ids-stable-output.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <rect id="a" width="80" height="50" fill="red"/>
+  <rect id="b" width="80" height="50" fill="blue"/>
+ </defs>
+ <use xlink:href="#a"/>
+ <use xlink:href="#b"/>
+ <use xlink:href="#b"/>
+</svg>
+


### PR DESCRIPTION
This patch enables shortenIDs to remap IDs currently in use.  This is
very helpful to ensure that scour does not change been "optimal" and
"suboptimal" choices for IDs as observed in GH#186.

Closes: #186
Signed-off-by: Niels Thykier <niels@thykier.net>