### PR TITLE
Avoid crashing on "scale(1)" (short for "scale(1, 1)")

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2966,7 +2966,9 @@ def optimizeTransform(transform):
                 # y1 * uniformscalefactor2
                 prevArgs[1] *= currArgs[0]
             del transform[i]
-            if prevArgs[0] == prevArgs[1] == 1:
+            # if prevArgs is [1] or [1, 1], then it is effectively an
+            # identity matrix and can be removed.
+            if prevArgs[0] == 1 and (len(prevArgs) == 1 or prevArgs[1] == 1):
                 # Identity scale!
                 i -= 1
                 del transform[i]

--- a/testscour.py
+++ b/testscour.py
@@ -2304,6 +2304,17 @@ class TransformIdentityTranslate(unittest.TestCase):
                          'Transform containing identity translation not removed')
 
 
+class TransformIdentityScale(unittest.TestCase):
+
+    def runTest(self):
+        try:
+            doc = scourXmlFile('unittests/transform-scale-is-identity.svg')
+        except IndexError:
+            self.fail("scour failed to handled scale(1) [See GH#190]")
+        self.assertEqual(doc.getElementsByTagName('line')[0].getAttribute('scale'), '',
+                         'Transform containing identity translation not removed')
+
+
 class DuplicateGradientsUpdateStyle(unittest.TestCase):
 
     def runTest(self):

--- a/unittests/transform-scale-is-identity.svg
+++ b/unittests/transform-scale-is-identity.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="-9 0 9 9">
+ <line stroke="rgba(255,0,0,0.5)" y1="9" x1="9" transform="scale(1 1) scale(1)"/>
+ <line stroke="rgba(0,0,255,0.5)" y1="9" x1="9"/>
+</svg>


### PR DESCRIPTION
The scale function on the transform attribute has a short form, where
only the first argument is used.  But optimizeTransform would always
assume that there were two when checking for the identity scale.

Closes: #190
Signed-off-by: Niels Thykier <niels@thykier.net>