### PR TITLE
removeDefaultAttributeValue: Special-case order attribute

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1830,9 +1830,12 @@ default_attributes = [
     DefaultAttribute('spreadMethod', 'pad', elements=['linearGradient', 'radialGradient']),
 
     # filter effects
+    #   TODO: Some numerical attributes allow an optional second value ("number-optional-number")
+    #         and are currently handled as strings to avoid an exception in 'SVGLength', see
+    #         https://github.com/scour-project/scour/pull/192
     DefaultAttribute('amplitude', 1, elements=['feFuncA', 'feFuncB', 'feFuncG', 'feFuncR']),
     DefaultAttribute('azimuth', 0, elements=['feDistantLight']),
-    DefaultAttribute('baseFrequency', 0, elements=['feFuncA', 'feFuncB', 'feFuncG', 'feFuncR']),
+    DefaultAttribute('baseFrequency', '0', elements=['feFuncA', 'feFuncB', 'feFuncG', 'feFuncR']),
     DefaultAttribute('bias', 1, elements=['feConvolveMatrix']),
     DefaultAttribute('diffuseConstant', 1, elements=['feDiffuseLighting']),
     DefaultAttribute('edgeMode', 'duplicate', elements=['feConvolveMatrix']),
@@ -1848,21 +1851,16 @@ default_attributes = [
     DefaultAttribute('offset', 0, elements=['feFuncA', 'feFuncB', 'feFuncG', 'feFuncR']),
     DefaultAttribute('operator', 'over', elements=['feComposite']),
     DefaultAttribute('operator', 'erode', elements=['feMorphology']),
-    # We pretend order is a string (because handling it as an
-    # SVGLength will cause issues when order is two integers).  Note
-    # that order must be exactly one or two integers (no units or
-    # fancy numbers), so working with it a string will generally just
-    # work.
     DefaultAttribute('order', '3', elements=['feConvolveMatrix']),
     DefaultAttribute('pointsAtX', 0, elements=['feSpotLight']),
     DefaultAttribute('pointsAtY', 0, elements=['feSpotLight']),
     DefaultAttribute('pointsAtZ', 0, elements=['feSpotLight']),
     DefaultAttribute('preserveAlpha', 'false', elements=['feConvolveMatrix']),
+    DefaultAttribute('radius', '0', elements=['feMorphology']),
     DefaultAttribute('scale', 0, elements=['feDisplacementMap']),
     DefaultAttribute('seed', 0, elements=['feTurbulence']),
     DefaultAttribute('specularConstant', 1, elements=['feSpecularLighting']),
     DefaultAttribute('specularExponent', 1, elements=['feSpecularLighting', 'feSpotLight']),
-    # Pretend it is a string (for the same reasons as we do with "order")
     DefaultAttribute('stdDeviation', '0', elements=['feGaussianBlur']),
     DefaultAttribute('stitchTiles', 'noStitch', elements=['feTurbulence']),
     DefaultAttribute('surfaceScale', 1, elements=['feDiffuseLighting', 'feSpecularLighting']),

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1862,7 +1862,8 @@ default_attributes = [
     DefaultAttribute('seed', 0, elements=['feTurbulence']),
     DefaultAttribute('specularConstant', 1, elements=['feSpecularLighting']),
     DefaultAttribute('specularExponent', 1, elements=['feSpecularLighting', 'feSpotLight']),
-    DefaultAttribute('stdDeviation', 0, elements=['feGaussianBlur']),
+    # Pretend it is a string (for the same reasons as we do with "order")
+    DefaultAttribute('stdDeviation', '0', elements=['feGaussianBlur']),
     DefaultAttribute('stitchTiles', 'noStitch', elements=['feTurbulence']),
     DefaultAttribute('surfaceScale', 1, elements=['feDiffuseLighting', 'feSpecularLighting']),
     DefaultAttribute('type', 'matrix', elements=['feColorMatrix']),

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1848,7 +1848,12 @@ default_attributes = [
     DefaultAttribute('offset', 0, elements=['feFuncA', 'feFuncB', 'feFuncG', 'feFuncR']),
     DefaultAttribute('operator', 'over', elements=['feComposite']),
     DefaultAttribute('operator', 'erode', elements=['feMorphology']),
-    DefaultAttribute('order', 3, elements=['feConvolveMatrix']),
+    # We pretend order is a string (because handling it as an
+    # SVGLength will cause issues when order is two integers).  Note
+    # that order must be exactly one or two integers (no units or
+    # fancy numbers), so working with it a string will generally just
+    # work.
+    DefaultAttribute('order', '3', elements=['feConvolveMatrix']),
     DefaultAttribute('pointsAtX', 0, elements=['feSpotLight']),
     DefaultAttribute('pointsAtY', 0, elements=['feSpotLight']),
     DefaultAttribute('pointsAtZ', 0, elements=['feSpotLight']),

--- a/testscour.py
+++ b/testscour.py
@@ -1570,6 +1570,16 @@ class RemoveDefaultGradFYValue(unittest.TestCase):
                          'fy matching cy not removed')
 
 
+class RemoveDefaultAttributeOrderSVGLengthCrash(unittest.TestCase):
+
+    # Triggered a crash in v0.36
+    def runTest(self):
+        try:
+            scourXmlFile('unittests/remove-default-attr-order.svg')
+        except AttributeError:
+            self.fail("Processing the order attribute triggered an AttributeError ")
+
+
 class CDATAInXml(unittest.TestCase):
 
     def runTest(self):

--- a/testscour.py
+++ b/testscour.py
@@ -1577,7 +1577,17 @@ class RemoveDefaultAttributeOrderSVGLengthCrash(unittest.TestCase):
         try:
             scourXmlFile('unittests/remove-default-attr-order.svg')
         except AttributeError:
-            self.fail("Processing the order attribute triggered an AttributeError ")
+            self.fail("Processing the order attribute triggered an AttributeError")
+
+
+class RemoveDefaultAttributeStdDeviationSVGLengthCrash(unittest.TestCase):
+
+    # Triggered a crash in v0.36
+    def runTest(self):
+        try:
+            scourXmlFile('unittests/remove-default-attr-std-deviation.svg')
+        except AttributeError:
+            self.fail("Processing the order attribute triggered an AttributeError")
 
 
 class CDATAInXml(unittest.TestCase):

--- a/unittests/remove-default-attr-order.svg
+++ b/unittests/remove-default-attr-order.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink= "http://www.w3.org/1999/xlink">
+  <defs>
+    <filter id="filter" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+      <feConvolveMatrix order="3 1" kernelMatrix="0.3333 0.3333 0.3333" edgeMode="none"/>
+    </filter>
+  </defs>
+  <!-- Use the filter (otherwise, scour discards it before it trips over it) -->
+  <image id="png" x="10" y="30" width="150" height="50" xlink:href="raster.png"
+         filter="url(#filter)"/>
+</svg>

--- a/unittests/remove-default-attr-order.svg
+++ b/unittests/remove-default-attr-order.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink= "http://www.w3.org/1999/xlink">
   <defs>
     <filter id="filter" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
-      <feConvolveMatrix order="3 1" kernelMatrix="0.3333 0.3333 0.3333" edgeMode="none"/>
+      <feConvolveMatrix order="3 1" kernelMatrix="0.3333 0.3333 0.3333" kernelUnitLength="3 1" edgeMode="none"/>
     </filter>
   </defs>
   <!-- Use the filter (otherwise, scour discards it before it trips over it) -->

--- a/unittests/remove-default-attr-std-deviation.svg
+++ b/unittests/remove-default-attr-std-deviation.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink= "http://www.w3.org/1999/xlink">
+  <defs>
+    <filter id="filter" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+      <feGaussianBlur stdDeviation="0 0" x="10" y="10" dx="20" dy="20" />
+    </filter>
+  </defs>
+  <!-- Use the filter (otherwise, scour discards it before it trips over it) -->
+  <image id="png" x="10" y="30" width="150" height="50" xlink:href="raster.png"
+         filter="url(#filter)"/>
+</svg>


### PR DESCRIPTION
Scour tried to handle "order" attribute as a SVGLength.  However, the
"order" attribute *can* consist of two integers according to the
[SVG 1.1 Specification] and SVGLength is not designed to handle that.

With this change, we now pretend that "order" is a string, which side
steps this issue.

[SVG 1.1 Specification]: https://www.w3.org/TR/SVG11/single-page.html#filters-feConvolveMatrixElementOrderAttribute

Closes: #189
Signed-off-by: Niels Thykier <niels@thykier.net>