### PR TITLE
WIP: Add optimization that prunes nested <g>-tags

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1017,8 +1017,12 @@ def removeDescriptiveElements(doc, options):
 def g_tag_is_unmergeable(node):
     """Check if a <g> tag can be merged or not
 
-    <g> tags with a title or descriptions should generally be left alone.
+    Generally, there are two types of <g> tags that should be left alone:
+     * <g> tags with a title or descriptions
+     * <g> tags that has an ID
     """
+    if node.getAttribute('id') != '':
+        return True
     return any(True for n in node.childNodes if n.nodeType == Node.ELEMENT_NODE
                and n.nodeName in ('title', 'desc') and n.namespaceURI == NS['SVG'])
 

--- a/test_scour.py
+++ b/test_scour.py
@@ -2075,6 +2075,104 @@ class MustKeepGInSwitch2(unittest.TestCase):
                          'Erroneously removed a <g> in a <switch>')
 
 
+class GroupParentMerge(unittest.TestCase):
+
+    def test_parent_merge(self):
+        doc = scourXmlFile('unittests/group-parent-merge.svg',
+                           parse_args([]))
+        g_tags = doc.getElementsByTagName('g')
+        attrs = {
+            'font-family': 'Liberation Sans,Arial,Helvetica,sans-serif',
+            'text-anchor': 'middle',
+            'font-weight': '400',
+            'font-size': '24',
+        }
+        self.assertEqual(g_tags.length, 1,
+                         'Inline single-child node <g> tags into parent <g>-tags')
+
+        g_tag = g_tags[0]
+        for attr_name, attr_value in attrs.items():
+
+            self.assertEqual(g_tag.getAttribute(attr_name), attr_value,
+                             'Parent now has inherited attributes of obsolete <g>-tags')
+
+    def test_parent_merge_disabled(self):
+        doc = scourXmlFile('unittests/group-parent-merge.svg',
+                           parse_args(['--disable-group-collapsing']))
+        g_tags = doc.getElementsByTagName('g')
+        attrs = {
+            'font-family': 'Liberation Sans,Arial,Helvetica,sans-serif',
+            'text-anchor': '',
+            'font-weight': '',
+            'font-size': '',
+        }
+        self.assertEqual(g_tags.length, 4,
+                         'Inline single-child node <g> tags into parent <g>-tags')
+
+        # There should be exactly one <g> tag in the top of the document
+        # Note that the order returned by getElementsByTagName is not specified
+        # so we do not rely on its return value
+        g_tags = [g for g in doc.documentElement.childNodes if g.nodeName == 'g']
+        self.assertEqual(len(g_tags), 1,
+                         'Optimization must not move the <g> up to the root')
+        g_tag = g_tags[0]
+        for attr_name, attr_value in attrs.items():
+            self.assertEqual(g_tag.getAttribute(attr_name), attr_value,
+                             'Parent now has inherited attributes of obsolete <g>-tags')
+
+    def test_parent_merge2(self):
+        doc = scourXmlFile('unittests/group-parent-merge2.svg',
+                           parse_args([]))
+        attrs = {
+            'font-family': 'Liberation Sans,Arial,Helvetica,sans-serif',
+            'text-anchor': 'middle',
+            'font-weight': '400',
+            'font-size': '',  # The top-level g-node cannot have gotten this.
+        }
+        # There is one inner <g> that cannot be optimized, so there must be 2
+        # <g> tags in total
+        self.assertEqual(doc.getElementsByTagName('g').length, 2,
+                         'Inline single-child node <g> tags into parent <g>-tags')
+
+        # There should be exactly one <g> tag in the top of the document
+        # Note that the order returned by getElementsByTagName is not specified
+        # so we do not rely on its return value
+        g_tags = [g for g in doc.documentElement.childNodes if g.nodeName == 'g']
+        self.assertEqual(len(g_tags), 1,
+                         'Optimization must not move the <g> up to the root')
+        g_tag = g_tags[0]
+        for attr_name, attr_value in attrs.items():
+            self.assertEqual(g_tag.getAttribute(attr_name), attr_value,
+                             'Parent now has inherited attributes of obsolete <g>-tags')
+
+    def test_parent_merge3(self):
+        doc = scourXmlFile('unittests/group-parent-merge3.svg',
+                           parse_args(['--protect-ids-list=foo']))
+        attrs = {
+            'font-family': 'Liberation Sans,Arial,Helvetica,sans-serif',
+            'text-anchor': 'middle',
+            'font-weight': '400',
+            'font-size': '',  # The top-level g-node cannot have gotten this.
+        }
+        # There is one inner <g> that cannot be optimized, so there must be 2
+        # <g> tags in total
+        self.assertEqual(doc.getElementsByTagName('g').length, 2,
+                         'Inline single-child node <g> tags into parent <g>-tags')
+
+        self.assertIsNotNone(doc.getElementById('foo'), 'The inner <g> was left untouched')
+
+        # There should be exactly one <g> tag in the top of the document
+        # Note that the order returned by getElementsByTagName is not specified
+        # so we do not rely on its return value
+        g_tags = [g for g in doc.documentElement.childNodes if g.nodeName == 'g']
+        self.assertEqual(len(g_tags), 1,
+                         'Optimization must not move the <g> up to the root')
+        g_tag = g_tags[0]
+        for attr_name, attr_value in attrs.items():
+            self.assertEqual(g_tag.getAttribute(attr_name), attr_value,
+                             'Parent now has inherited attributes of obsolete <g>-tags')
+
+
 class GroupSiblingMerge(unittest.TestCase):
 
     def test_sibling_merge(self):

--- a/unittests/group-parent-merge.svg
+++ b/unittests/group-parent-merge.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+ <g font-family="Liberation Sans,Arial,Helvetica,sans-serif">
+  <g text-anchor="middle">
+   <g font-weight="400">
+    <g font-size="24">
+     <text x="50" y="30">Text1</text>
+     <text x="50" y="55">Text2</text>
+     <text x="50" y="80">Text3</text>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/unittests/group-parent-merge2.svg
+++ b/unittests/group-parent-merge2.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+ <g font-family="Liberation Sans,Arial,Helvetica,sans-serif">
+  <g text-anchor="middle">
+   <g font-weight="400">
+   <text x="50" y="30">Text1</text>
+    <g font-size="24">
+     <text x="50" y="55">Text2</text>
+     <text x="50" y="80">Text3</text>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/unittests/group-parent-merge3.svg
+++ b/unittests/group-parent-merge3.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+ <g font-family="Liberation Sans,Arial,Helvetica,sans-serif">
+  <g text-anchor="middle">
+   <g font-weight="400">
+    <g id="foo" font-size="24">
+     <text x="50" y="30">Text1</text>
+     <text x="50" y="55">Text2</text>
+     <text x="50" y="80">Text3</text>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>


### PR DESCRIPTION
An optimization that prunes nested <g>-tags when they contain exactly one <g> and nothing else (except whitespace nodes).  This looks a bit like `removeNestedGroups` except it only touches <g> tags without attributes (but can remove <g>-tags completely from a tree, whereas this optimization always leaves at least one <g> tag behind).

Closes: #215
