### PR TITLE
Add support to ppc64le. Disable pypy as this is not supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 
 language: python
 
+arch:
+  - amd64
+  - ppc64le
+
 python:
   - pypy
   - 2.7
@@ -25,6 +29,15 @@ matrix:
     - python: 3.9
       env:
       - TOXENV=flake8
-
+    # Power job  
+    - python: 3.9
+      arch: ppc64le
+      env:
+      - TOXENV=flake8
+  
+  exclude:
+    - python: pypy
+      arch: ppc64le
+      
 after_success:
   - coverage combine && codecov


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues 
or failures early would help to ensure that we are always up to date.